### PR TITLE
Added Google Sheets example

### DIFF
--- a/google-sheets/Code.js
+++ b/google-sheets/Code.js
@@ -1,0 +1,563 @@
+//////// Start of button stub functions
+
+/**
+ * Roll a d20 using dddice and display the result.
+ */
+function rollD20() {
+  const roll_json = DDDICE_JSON_FROM_ARGS(1, "d20");
+  const result = DDDICE_ROLL_FROM_JSON(roll_json);
+
+  let ui = SpreadsheetApp.getUi();
+  ui.alert("Notice", `Your dddice roll result was: ${result}`, ui.ButtonSet.OK);
+}
+
+//////// End of button stub functions
+
+//////// Start of simple triggers
+
+/**
+ * The event handler triggered when opening the spreadsheet.
+ * @param {Event} e The onOpen event.
+ * @see https://developers.google.com/apps-script/guides/triggers#onopene
+ */
+function onOpen(e) {
+  addThreeDDiceMenu();
+}
+
+/**
+ * Adds the dddice menu
+ */
+function addThreeDDiceMenu() {
+  var ui = SpreadsheetApp.getUi();
+  ui.createMenu("dddice")
+    .addItem("Roll from JSON in active cell", "rollFromActiveCellJSON")
+    .addSeparator()
+    .addItem("Change the default dice theme", "promptUserForDiceTheme")
+    .addItem("Change the default room ID", "promptUserForRoomID")
+    .addSeparator()
+    .addSubMenu(
+      ui.createMenu("Admin actions")
+        .addItem("Change the user API key", "promptUserForAuthKey")
+        .addSeparator()
+        .addItem(
+          "Delete user property: user API key",
+          "deleteThreeDDiceAuthKey"
+        )
+        .addItem(
+          "Delete user property: default dice theme",
+          "deleteDefaultDiceTheme"
+        )
+        .addItem("Delete user property: default room ID", "deleteDefaultRoomID")
+        .addSeparator()
+        .addItem("Delete all dddice user properties", "deleteThreeDDiceProps")
+    )
+    .addToUi();
+}
+
+//////// End of simple triggers
+
+//////// Start of installable triggers
+
+/**
+ * An event handler which must be installed in the Triggers section.
+ * @param {Event} e The onEdit event.
+ */
+function onEditInstallable(e) {
+  // check if event has a range property
+  if (e.range) {
+    // check if event's range has a size of 1x1
+    if (e.range.getNumColumns() === 1 && e.range.getNumRows() === 1) {
+      // check if event's range is a checked checkbox
+      if (e.range.isChecked()) {
+        processThreeDDiceCheckbox(e.range);
+      }
+    }
+  }
+}
+
+/**
+ * Processes dddice roll from cells by checked checkbox.
+ * @param {Range} checkbox The Range of the checked checkbox.
+ */
+function processThreeDDiceCheckbox(checkbox) {
+  const ref_col = checkbox.getColumn();
+  const ref_row = checkbox.getRow();
+  let sheet = checkbox.getSheet();
+  let roll_result = null;
+  let roll_direction = null;
+
+  // start by looking to the right
+  try {
+    let cell_right = sheet.getRange(ref_row, ref_col + 1);
+    roll_result = DDDICE_ROLL_FROM_JSON(cell_right.getValue());
+    roll_direction = "right";
+  } catch {
+    // that didn't work. ensure roll_result and roll_direction are null
+    roll_result = null;
+    roll_direction = null;
+  }
+
+  if (roll_result === null) {
+    // couldn't roll to the right, so let's try below the checkbox
+    try {
+      let cell_down = sheet.getRange(ref_row + 1, ref_col);
+      roll_result = DDDICE_ROLL_FROM_JSON(cell_down.getValue());
+      roll_direction = "down";
+    } catch {
+      // that didn't work. ensure roll_result and roll_direction are null
+      roll_result = null;
+      roll_direction = null;
+    }
+  }
+
+  if (roll_direction !== null) {
+    // log the roll result just past the roll's JSON cell
+    let log_row = ref_row;
+    let log_col = ref_col;
+    if (roll_direction === "right") {
+      log_col = log_col + 2;
+    } else if (roll_direction === "down") {
+      log_row = log_row + 2;
+    } else {
+      Logger.log(`Unknown roll_direction: ${roll_direction}`);
+    }
+
+    // check to make sure we've made a change to the log coordinates
+    if (log_row !== ref_row || log_col !== ref_col) {
+      try {
+        let log_cell = sheet.getRange(log_row, log_col);
+        log_cell.setValue(roll_result);
+      } catch {
+        // no log cell to record the result
+      }
+    }
+  }
+
+  // reset the checkbox if we successfully rolled
+  if (roll_result !== null) {
+    checkbox.uncheck();
+  }
+}
+
+//////// End of installable triggers
+
+//////// Start of custom functions
+
+/**
+ * Formats dice roll arguments into a parseable JSON string for rolling.
+ * @param {number} dice_number The number of dice to roll.
+ * @param {string} dice_type The type of dice to roll. Must be "d20", "d12", "d10", "d10x", "d8", "d6", "d4", or "mod".
+ * @param {number} roll_modifier Optional modifier to the roll.
+ * @param {string} dice_theme Optional dice theme ID to use instead of default theme.
+ * @param {string} room_id Optional room ID to send roll to instead of default room.
+ * @param {string} extra_dice_args_string Optional JSON string to add to die/dice.
+ * @param {string} extra_roll_args_string Optional JSON string to add to roll.
+ * @returns {string} A JSON string summarizing the roll info.
+ * @customfunction
+ */
+function DDDICE_JSON_FROM_ARGS(
+  dice_number,
+  dice_type,
+  roll_modifier,
+  dice_theme,
+  room_id,
+  extra_dice_args_string,
+  extra_roll_args_string
+) {
+  // define the die/dice for this roll
+  let die_to_add = {};
+  die_to_add.number = parseInt(dice_number);
+  die_to_add.type = dice_type;
+  if (dice_theme) die_to_add.theme = dice_theme;
+  if (extra_dice_args_string) {
+    const extra_dice_args = JSON.parse(extra_dice_args_string);
+    die_to_add = addNewKeysFromObjectToObject(die_to_add, extra_dice_args);
+  }
+
+  // define the JSON for this roll
+  let roll_json = {
+    dice_to_add: [die_to_add],
+  };
+  if (roll_modifier) roll_json.roll_modifier = parseInt(roll_modifier);
+  if (room_id) roll_json.room = room_id;
+  if (extra_roll_args_string) {
+    const extra_roll_args = JSON.parse(extra_roll_args_string);
+    roll_json = addNewKeysFromObjectToObject(roll_json, extra_roll_args);
+  }
+
+  // add a key for readability in the cell
+  let output = {
+    dddice_roll: roll_json,
+  };
+  return JSON.stringify(output);
+}
+
+/**
+ * Combines multiple dddice roll JSONs into one roll.
+ * @param {string[]} json_strings The JSON strings to combine.
+ * @returns {string} The combined dddice JSON string.
+ * @customfunction
+ */
+function COMBINE_DDDICE_JSONS(...json_strings) {
+  let roll_json = {
+    dice_to_add: [],
+  };
+  for (let i = 0; i < json_strings.length; i++) {
+    let parsed_json;
+    try {
+      parsed_json = JSON.parse(json_strings[i]);
+    } catch {
+      continue;
+    }
+    let roll_i = parsed_json.hasOwnProperty("dddice_roll")
+      ? parsed_json["dddice_roll"]
+      : parsed_json;
+
+    if (roll_i.hasOwnProperty("dice")) {
+      if (!roll_json.hasOwnProperty("dice")) {
+        roll_json.dice = [];
+      }
+      roll_json.dice.push(...roll_i.dice);
+    }
+
+    if (roll_i.hasOwnProperty("dice_to_add")) {
+      roll_json.dice_to_add.push(...roll_i.dice_to_add);
+    }
+
+    if (roll_i.hasOwnProperty("roll_modifier")) {
+      if (!roll_json.hasOwnProperty("roll_modifier")) {
+        roll_json.roll_modifier = 0;
+      }
+      roll_json.roll_modifier = roll_json.roll_modifier + roll_i.roll_modifier;
+    }
+
+    // add the rest of the keys, ignoring new value if key already exists
+    roll_json = addNewKeysFromObjectToObject(roll_json, roll_i);
+  }
+
+  // add a key for readability in the cell
+  let output = {
+    dddice_roll: roll_json,
+  };
+  return JSON.stringify(output);
+}
+
+//////// End of custom functions
+
+/**
+ * Adds key-value pairs to an object if not yet defined.
+ * @param {Object} target_object Object to add new keys to.
+ * @param {Object} object_to_add Object adding keys from.
+ * @returns {Object} New combined object.
+ */
+function addNewKeysFromObjectToObject(target_object, object_to_add) {
+  const current_keys = Object.keys(target_object);
+  const keys_to_add = Object.keys(object_to_add);
+  for (let i = 0; i < keys_to_add.length; i++) {
+    let key_i = keys_to_add[i];
+    if (!current_keys.includes(key_i)) {
+      target_object[key_i] = object_to_add[key_i];
+    }
+  }
+  return target_object;
+}
+
+/**
+ * Rolls selected JSON and displays the value
+ */
+function rollFromActiveCellJSON() {
+  const result = DDDICE_ROLL_FROM_JSON(
+    SpreadsheetApp.getActiveRange().getValue()
+  );
+
+  let ui = SpreadsheetApp.getUi();
+  ui.alert("Notice", `Your dddice roll result was: ${result}`, ui.ButtonSet.OK);
+}
+
+/**
+ * Executes a dddice roll defined by the input JSON string.
+ * @param {string} json_string JSON string defining dddice roll.
+ * @returns {number} The total value of the roll.
+ */
+function DDDICE_ROLL_FROM_JSON(json_string) {
+  const url = "https://dddice.com/api/1.0/roll";
+
+  const auth_key = getThreeDDiceAuthKey();
+  const headers = {
+    Authorization: `Bearer ${auth_key}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  const body = convertJSONStringToBody(json_string);
+
+  let response = UrlFetchApp.fetch(url, {
+    method: "POST",
+    headers: headers,
+    payload: JSON.stringify(body),
+  });
+  const response_json = JSON.parse(response.getContentText());
+  return response_json.data.total_value;
+}
+
+/**
+ * Converts the summary JSON string into the body format expected by the dddice API
+ * @param {string} json_string JSON string defining a dddice roll.
+ * @returns {Object} The body object, formatted in the way the dddice API expects.
+ */
+function convertJSONStringToBody(json_string) {
+  if (json_string === undefined)
+    json_string = '{"dice_to_add":[{"number":1,"type":"d20"}]}';
+  const parsed_json = JSON.parse(json_string);
+  let roll_json = parsed_json.hasOwnProperty("dddice_roll")
+    ? parsed_json["dddice_roll"]
+    : parsed_json;
+
+  // create the dice array, unless it already exists
+  if (!roll_json.hasOwnProperty("dice")) roll_json.dice = [];
+
+  // add all the dice described in the dice_to_add array
+  if (roll_json.hasOwnProperty("dice_to_add")) {
+    roll_json.dice.push(...convertDiceToAddArray(roll_json.dice_to_add));
+    delete roll_json.dice_to_add; // clean up afterwards
+  }
+
+  // add the roll modifier if provided
+  if (roll_json.hasOwnProperty("roll_modifier")) {
+    roll_json.dice.push({
+      type: "mod",
+      value: roll_json.roll_modifier,
+    });
+    delete roll_json.roll_modifier; // clean up afterwards
+  }
+
+  // add the default dice theme to all dice which don't already have a theme
+  const default_dice_theme = getDefaultDiceTheme();
+  for (let i = 0; i < roll_json.dice.length; i++) {
+    if (!roll_json.dice[i].hasOwnProperty("theme")) {
+      roll_json.dice[i].theme = default_dice_theme;
+    }
+  }
+
+  // add the default room ID if none already specified
+  if (!roll_json.hasOwnProperty("room")) {
+    const default_room_id = getDefaultRoomID();
+    if (default_room_id) roll_json.room = default_room_id;
+  }
+
+  return roll_json;
+}
+
+/**
+ * Converts the summary array of dice to the API-style dice array.
+ * @param {Array} dice_to_add Summary array of dice to be converted.
+ * @returns {Array} The dice array in the API format.
+ */
+function convertDiceToAddArray(dice_to_add) {
+  let output = [];
+  for (let i = 0; i < dice_to_add.length; i++) {
+    let die_to_add = {
+      type: dice_to_add[i].type,
+    };
+    if (dice_to_add[i].hasOwnProperty("theme")) {
+      die_to_add.theme = dice_to_add[i].theme;
+    }
+    let number_to_add = dice_to_add[i].hasOwnProperty("number")
+      ? dice_to_add[i].number
+      : 1;
+    for (let j = 0; j < number_to_add; j++) {
+      output.push(die_to_add);
+    }
+  }
+  return output;
+}
+
+/**
+ * Gets the dddice user API key, prompting the user if not yet defined.
+ * @returns {string} The dddice user API key.
+ */
+function getThreeDDiceAuthKey() {
+  let user_props = PropertiesService.getUserProperties();
+  let dddice_auth_key = user_props.getProperty("dddice_auth_key");
+  if (dddice_auth_key === null) {
+    return promptUserForAuthKey();
+  }
+  return dddice_auth_key;
+}
+
+/**
+ * Gets the default dice theme, prompting the user if not yet defined.
+ * @returns {string} The default dddice dice theme.
+ */
+function getDefaultDiceTheme() {
+  let user_props = PropertiesService.getUserProperties();
+  let dddice_default_dice_theme = user_props.getProperty(
+    "dddice_default_dice_theme"
+  );
+  if (dddice_default_dice_theme === null) {
+    return promptUserForDiceTheme();
+  }
+  return dddice_default_dice_theme;
+}
+
+/**
+ * Gets the default room ID, prompting the user if not yet defined.
+ * @returns {string} The default dddice room ID.
+ */
+function getDefaultRoomID() {
+  let user_props = PropertiesService.getUserProperties();
+  let dddice_default_room_id = user_props.getProperty("dddice_default_room_id");
+  if (dddice_default_room_id === null) {
+    return promptUserForRoomID();
+  }
+  return dddice_default_room_id;
+}
+
+/**
+ * Prompts the user for their dddice API key. If provided, stores as a user property.
+ * @returns {string|null} The user API key or null if not provided.
+ */
+function promptUserForAuthKey() {
+  let ui = SpreadsheetApp.getUi();
+  let response = ui.prompt(
+    "User property input",
+    "Please provide your user API key for dddice.",
+    ui.ButtonSet.OK_CANCEL
+  );
+  if (response.getSelectedButton() != ui.Button.OK) return null;
+  const auth_key = response.getResponseText();
+  PropertiesService.getUserProperties().setProperty(
+    "dddice_auth_key",
+    auth_key
+  );
+  return auth_key;
+}
+
+/**
+ * Prompts the user for a default dice theme. Stores result as a user property.
+ * @returns {string} The default dice theme. Uses "dddice-red" if not provided.
+ */
+function promptUserForDiceTheme() {
+  let ui = SpreadsheetApp.getUi();
+  let response = ui.prompt(
+    "User property input",
+    "Please provide a default dice theme for dddice rolls.",
+    ui.ButtonSet.OK_CANCEL
+  );
+  let dice_theme = response.getResponseText();
+  if (!dice_theme) {
+    const fallback_dice_theme = "dddice-red";
+    dice_theme = fallback_dice_theme;
+  }
+  PropertiesService.getUserProperties().setProperty(
+    "dddice_default_dice_theme",
+    dice_theme
+  );
+  return dice_theme;
+}
+
+/**
+ * Prompts the user for a default room ID. Stores result as a user property.
+ * @returns {string} The default room ID. Uses "" if not provided.
+ */
+function promptUserForRoomID() {
+  let ui = SpreadsheetApp.getUi();
+  let response = ui.prompt(
+    "User property input",
+    "Please provide a default room ID for dddice rolls.",
+    ui.ButtonSet.OK_CANCEL
+  );
+  let room_id = response.getResponseText();
+  if (!room_id) {
+    const fallback_room_id = "";
+    room_id = fallback_room_id;
+  }
+  PropertiesService.getUserProperties().setProperty(
+    "dddice_default_room_id",
+    room_id
+  );
+  return room_id;
+}
+
+/**
+ * Deletes all the dddice user properties after confirmation.
+ */
+function deleteThreeDDiceProps() {
+  let ui = SpreadsheetApp.getUi();
+  const response = ui.alert(
+    "Confirm deletion",
+    "Are you sure you want to delete ALL the dddice user properties?",
+    ui.ButtonSet.YES_NO
+  );
+  if (response !== ui.Button.YES) {
+    return;
+  }
+
+  const confirmed = true;
+  deleteThreeDDiceAuthKey(confirmed);
+  deleteDefaultDiceTheme(confirmed);
+  deleteDefaultRoomID(confirmed);
+}
+
+/**
+ * Deletes the dddice API key from the user properties after confirmation.
+ * @param {bool} confirmed If true, skips user confirmation.
+ */
+function deleteThreeDDiceAuthKey(confirmed) {
+  if (!confirmed) {
+    let ui = SpreadsheetApp.getUi();
+    const response = ui.alert(
+      "Confirm deletion",
+      "Are you sure you want to delete the user property: user API key?",
+      ui.ButtonSet.YES_NO
+    );
+    if (response !== ui.Button.YES) {
+      return;
+    }
+  }
+
+  PropertiesService.getUserProperties().deleteProperty("dddice_auth_key");
+}
+
+/**
+ * Deletes the default dice theme from the user properties after confirmation.
+ * @param {bool} confirmed If true, skips user confirmation.
+ */
+function deleteDefaultDiceTheme(confirmed) {
+  if (!confirmed) {
+    let ui = SpreadsheetApp.getUi();
+    const response = ui.alert(
+      "Confirm deletion",
+      "Are you sure you want to delete the user property: default dice theme?",
+      ui.ButtonSet.YES_NO
+    );
+    if (response !== ui.Button.YES) {
+      return;
+    }
+  }
+
+  PropertiesService.getUserProperties().deleteProperty(
+    "dddice_default_dice_theme"
+  );
+}
+
+/**
+ * Deletes the default room ID from the user properties after confirmation.
+ * @param {bool} confirmed If true, skips user confirmation.
+ */
+function deleteDefaultRoomID(confirmed) {
+  if (!confirmed) {
+    let ui = SpreadsheetApp.getUi();
+    const response = ui.alert(
+      "Confirm deletion",
+      "Are you sure you want to delete the user property: default room ID?",
+      ui.ButtonSet.YES_NO
+    );
+    if (response !== ui.Button.YES) {
+      return;
+    }
+  }
+
+  PropertiesService.getUserProperties().deleteProperty(
+    "dddice_default_room_id"
+  );
+}

--- a/google-sheets/README.md
+++ b/google-sheets/README.md
@@ -1,0 +1,97 @@
+# dddice Google Sheets Example
+
+An example of how to use the dddice API in Google Sheets using Google Apps Script.
+
+## Usage
+
+To use this example, you'll have to create a Google Apps Script attached to a spreadsheet and authorize it. To do so:
+
+1. Open the Google Sheets spreadsheet you want to roll from.
+2. Open the **Apps Script** editor in the **Extensions** menu.
+3. Give your new Apps Script project a name, such as "dddice roller"
+4. Copy-paste the contents of the `Code.js` file into the editor (replacing the empty `myFunction` which is there) and save.
+5. At the top of the editor, click "Run" to execute the `rollD20` function.
+6. An "Authorization required" popup will open. Select "Review permissions" from it.
+7. Choose your Google account if prompted to do so.
+8. At the "Google hasn't verified this app" screen, select "Advanced" in the lower-left corner, followed by "Go to dddice roller (unsafe)".
+9. Unfortunately, the permissions are rather scary looking even though the script will only edit the spreadsheet you're in. Click "Allow" to continue.
+10. Return to the spreadsheet, and you'll see a popup titled "User property input" which is asking for your dddice API key. You need one to continue, so go to [dddice.com/account/developer](https://dddice.com/account/developer)
+11. Click "Create API Key" which will generate a key and copy it to your clipboard.
+12. Return to the spreadsheet and paste the API key into the popup's input. Click "Ok" to continue.
+13. You will now see a popup asking for a default dice theme to use for dddice rolls; a dice theme's ID is the last part of the URL of its [dice page](https://dddice.com/dice). If you're not sure what theme to use, click "Ok" and it will default to "dddice-red". 
+14. Next, you'll be asked for a default room ID for your dddice rolls. If you have a room you want to roll to, copy-paste its ID (the last part of the room's URL). Otherwise, you can leave it blank and click "Ok" to continue with no room.
+15. Finally, you'll get a popup titled "Notice" with the result of your d20 roll. If you put in a room ID in the last step, you should see the roll in there too!
+
+### The dddice Menu: Editing the User Properties
+
+If you want to edit the API key, the default dice theme, or the default room ID, it's easy to do so using the **dddice** menu which the script adds to your spreadsheet. If you don't see it, refresh your spreadsheet (this will close the Apps Script editor) or run the `onOpen` function.
+
+The **dddice** menu has several options:
+
+- **Roll from JSON in active cell**
+  - Highlight a cell containing the JSON string result of the `DDDICE_JSON_FROM_ARGS` custom function and select this option to roll it.
+- **Change the default dice theme**
+  - Selecting this prompts you to enter a new default dice theme.
+- **Change the default room ID**
+  - Selecting this prompts you to enter a new default room ID.
+- **Admin actions**
+  - These are actions you're probably going to need less often. Using these, you can change the user API key or delete any/all of the user properties stored by the script.
+
+### Custom Functions
+
+The script adds two new custom functions for you to use:
+
+- **`DDDICE_JSON_FROM_ARGS`**
+  - This function lets you specify a dddice roll: you can roll 1 or more of the same type of die, add a modifier, specify a different theme or room ID, and you can add additional API parameters as a JSON string.
+  - The output of this function is just a JSON string; it doesn't actually trigger the roll. To do so, highlight the cell and select **Roll from JSON in active cell** in the **dddice** menu.
+- **`COMBINE_DDDICE_JSONS`**
+  - This function lets you combine multiple dddice JSON strings into one so you can do more complex rolls involving multiple types of dice.
+  - Just like with the other function, the output of this is just a JSON string which you can roll from using the **dddice** menu.
+
+As an example, let's say we have the following:
+
+- In cell **B2**: `=DDDICE_JSON_FROM_ARGS(1, "d20", 7)`
+  - This would roll `1d20 + 7` with the default dice theme in the default room.
+- In cell **B3**: `=DDDICE_JSON_FROM_ARGS(1, "d8", 4)`
+  - This would roll `1d8 + 4` with the default dice theme in the default room.
+- In cell **B4**: `=DDDICE_JSON_FROM_ARGS(3, "d6", 0, "dddice-black", , "{""label"": ""Sneak Attack""}")`
+  - This would roll `3d6` with the "dddice-black" theme in the default room, with the added label of "Sneak Attack".
+- In cell **B5**: `=COMBINE_DDDICE_JSONS(B3, B4)`
+  - This would roll the two above rolls at the same time.
+
+### Activating with Checkboxes
+
+Opening the **dddice** menu for every roll is a lot of clicks, so I've added an option to activate dice rolls with checkboxes. To do so, you need to install a trigger for a function.
+
+1. Open the Apps Script editor.
+2. Open the "Triggers" section from the left-side menu.
+3. In the bottom-right corner, click the "Add Trigger" button.
+4. Under "Choose which function to run", select the `onEditInstallable` function from the dropdown.
+5. Under "Select event type", select "On edit" from the dropdown.
+6. Click "Save".
+
+Now, whenever you edit the spreadsheet, the `onEditInstallable` function will be called. That function checks if you've just checked a checkbox, and if you have, it will call the `processThreeDDiceCheckbox` function. That function looks to the right of the checkbox for a dddice roll JSON, and if it can't find one there, it looks under the checkbox. If it successfully rolls from one of those neighboring cells, it will try to put the result of that roll into the cell that's just past the JSON cell. Finally, if it was able to do a roll, the script will uncheck the checkbox.
+
+To try it out, first populate cells **B2:B5** as described in the example above. Then highlight cells **A2:A5** and click **Insert** > **Checkbox** from the top menu. Now if you check one of those checkboxes, the roll right next to it will be executed, and the result will be put into column **C**. The checkbox then gets unchecked so you can click it again.
+
+### Activating with Buttons
+
+There's another option for activating dddice rolls: making a "button" which is a drawing with an attached script. This option will be most useful to you if you're comfortable adding new functions in the Apps Script editor. JavaScript experience is helpful.
+
+To add a button, do the following:
+
+1. In the spreadsheet, click **Insert** > **Drawing** from the top menu.
+2. In the drawing editor popup, make a drawing. For example, click **Shape** > **Shapes** > **Rectangle** from the menu and draw it in.
+3. Click "Save and Close" in the upper-right corner.
+4. Your drawing should now be in the spreadsheet, above the cells. Move and resize it until you're satisfied with its position.
+5. With the drawing selected, three dots should appear in its upper-right corner. Click those dots and select "Assign script" from the menu that it opens.
+6. In the "Assign script" popup, type in the name of the function you want to use. For example, you could type in `rollD20` or `rollFromActiveCellJSON`. Click "OK".
+7. You've now set up your drawing as a button! Click it to activate the function.
+
+If you want to make any changes to the button (e.g. move/resize it, change the function, delete it), you'll have to `right-click` or `Ctrl/Cmd + left-click` it to select it and not activate the function.
+
+There's a section at the top of the script for "button stub functions" with an example function: `rollD20`. You can add your own button functions, using that function as an example. If you want to make reference to particular cell values within a function, that will require more work on your part; I suggest just using `DDDICE_JSON_FROM_ARGS` and `COMBINE_DDDICE_JSONS` to roll while referencing cell values.
+
+## Credits
+
+This example was written in response to [an integration request](https://discord.com/channels/905202772482359327/1074475474916474950/1074475474916474950) on the dddice Discord server. This work is based on [an example function](https://discord.com/channels/905202772482359327/1074475474916474950/1100183389228761228) written by another user in that thread.


### PR DESCRIPTION
## What's in this PR?
This PR includes an example of how to work with the dddice API in Google Sheets using Google Apps Script. I tried to make this as easy-to-use I could. The user API key is stored in the [User Properties](https://developers.google.com/apps-script/guides/properties), so it won't appear as plaintext in the spreadsheet or the script (unless you edit the script to specifically do so). The functions are documented within the script, and the README was written assuming little to no prior experience with Google Apps Script.

This PR is in response to [this integration request in the dddice Discord server](https://discord.com/channels/905202772482359327/1074475474916474950/1074475474916474950).

## Testing
I've tested this extensively in a sandbox spreadsheet, including a brand new one, so the README instructions should be accurate as of today.

## Known Issues
Google Apps Script can be slow and can easily error out, especially if too many calls are made too quickly. The interface I present here is clunky, but it should at least be easy to predict when your dddice rolls will activate, which is not the case if you send the API request from a custom function in a cell (an example of something I tried while working on this).

## Followup Work
This is not too far removed from being a fully-fledged [Google Sheets Add-On](https://developers.google.com/apps-script/add-ons/editors/sheets), but I'm not interested right now in doing the work needed to publish it as one. The dddice team is welcome to build off of this example if they decide to make a dddice Google Add-On.
